### PR TITLE
루틴 수정 이후 업데이트 되지 않는 버그 수정

### DIFF
--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -11,9 +11,6 @@ on:
 jobs:
   check:
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        node-version: [20]
 
     steps:
       - uses: actions/checkout@v4
@@ -22,10 +19,10 @@ jobs:
         with:
           version: 9.0.0
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20
           cache: "pnpm"
 
       - name: Install dependencies

--- a/src/pages/RoutineEditPage/index.tsx
+++ b/src/pages/RoutineEditPage/index.tsx
@@ -10,11 +10,10 @@ export default function RoutineUpdatePage() {
   const { routineId } = useParams();
 
   const { isLoading, data } = useQuery({
-    queryKey: ["routine", routineId],
+    queryKey: ["routines", routineId],
     queryFn: () => routineApi.getRoutine(parseInt(routineId!)),
     enabled: !!(routineId && !isNaN(parseInt(routineId))),
     refetchOnWindowFocus: true,
-    retry: false,
   });
 
   if (isLoading) {


### PR DESCRIPTION
Fix #80 

- 루틴 목록 자체는 업데이트가 되고 있었는데, 개별 루틴 api의 query key를 다르게 입력하고 있었어서 캐싱이 계속 유지되고 있었습니다.
- 그래서 루틴 목록과 동일하게 query key를 수정했습니다.