### PR TITLE
잘못 설정된 CI 순서 수정

### DIFF
--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -14,16 +14,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.0.0
 
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "pnpm"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
- 기존에 실수로 node 설정 이전에 pnpm을 설치하는 순서로 설정해뒀던걸 이제야 발견했습니다.
- 아마 기존엔 기본 내장된 nodejs를 사용해서 pnpm을 설치했기 때문에 문제가 없었던 것 같습니다.
- 순서를 제대로 변경했습니다.