### PR TITLE
Alert의 가로 길이 조정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import Messages from "./components/Messages";
 function App() {
   return (
     <>
-      <div className="container max-w-xl mx-auto flex flex-col h-screen">
+      <div className="relative container max-w-xl mx-auto flex flex-col h-screen">
         <NavBar />
 
         <div className="flex-1 w-full overflow-y-auto">
@@ -18,10 +18,10 @@ function App() {
         </div>
 
         <BottomNavigation />
+        <Messages />
       </div>
 
       <TokenRefresher />
-      <Messages />
     </>
   );
 }

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -5,7 +5,6 @@ import {
   BsExclamationCircle,
   BsInfoCircle,
 } from "react-icons/bs";
-import { createPortal } from "react-dom";
 import { useMemo } from "react";
 
 import { MessageType, useMessageStore } from "@/state/useMessageStore";

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -64,13 +64,10 @@ export default function Messages() {
   }, [clearMessage, messages]);
 
   return (
-    <>
-      {createPortal(
-        <div className={`fixed bottom-0 w-full p-3 flex flex-col gap-3 z-50`}>
-          {messageList}
-        </div>,
-        document.body
-      )}
-    </>
+    <div
+      className={`absolute left-0 right-0 bottom-0 flex flex-col gap-3 z-50`}
+    >
+      {messageList}
+    </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* daisyui의 modal 오픈 시 생기는 scrollbar gutter 제거  */
+:root:has(
+    :is(
+      .modal-open,
+      .modal:target,
+      .modal-toggle:checked + .modal,
+      .modal[open]
+    )
+  ) {
+  scrollbar-gutter: inherit;
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cd4bcd78-5f60-4f30-80c6-936da8758566)

- Alert의 가로 길이를 현재 지원하는 최대 width까지만 늘어나도록 수정했습니다.
- 추가로 모달이 열릴 때 daisy에서 html root에 scrollbar를 자동으로 추가하게 되어 있길래 설정을 override해서 없앴습니다.