### PR TITLE
회원가입 실패 메시지 오타 수정

### DIFF
--- a/src/pages/SignUpPage/index.tsx
+++ b/src/pages/SignUpPage/index.tsx
@@ -14,7 +14,7 @@ const messages: { [key: string]: { [key: string]: string } } = {
     VALUE_TOO_SHORT: "아이디는 4자 이상이어야 합니다.",
     VALUE_TOO_LONG: "아이디는 20자 이하이어야 합니다.",
     VALUE_MUST_BE_ALPHANUM: "아이디는 영문 혹은 영문과 숫자를 조합해주세요.",
-    UserNAME_ALREADY_EXISTS:
+    USERNAME_ALREADY_EXISTS:
       "이미 사용중인 아이디입니다. 다른 아이디를 입력해주세요.",
   },
   password: {
@@ -78,7 +78,8 @@ const SignUpPage = () => {
         }
       } else if (error.response?.status === 409) {
         const { error_type } = error.response.data;
-        if (error_type == "UserNAME_ALREADY_EXISTS") {
+
+        if (error_type == "USERNAME_ALREADY_EXISTS") {
           addMessage({
             message: messages.username[error_type],
             type: "warning",


### PR DESCRIPTION
- 기존에 회원가입 실패 시, 이미 존재하는 id를 처리하는 message if문에 오타가 있었습니다.
- 이전에 리팩토링 하면서 다른 변수 이름을 치환할 때 실수했습니다. 수정했습니다.