### PR TITLE
스크롤 영역 변경 및 메인 페이지 UI 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,13 +8,11 @@ import Messages from "./components/Messages";
 function App() {
   return (
     <>
-      <div className="relative container max-w-xl mx-auto flex flex-col h-screen">
+      <div className="relative overflow-y-auto min-h-screen flex flex-col root-content">
         <NavBar />
 
-        <div className="flex-1 w-full overflow-y-auto">
-          <div className="w-full min-h-full flex flex-col mx-auto max-w-md font-sans py-5 px-10">
-            <Outlet />
-          </div>
+        <div className="px-8 pt-20 pb-20 flex-1">
+          <Outlet />
         </div>
 
         <BottomNavigation />

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -8,44 +8,57 @@ import {
 
 import Routes from "@/constants/routes";
 
+const NavigationList = [
+  {
+    to: `/${Routes.Main}`,
+    icon: <BsHouseDoor />,
+    label: "Home",
+  },
+  {
+    to: `/${Routes.Todo}`,
+    icon: <BsCheck2Square />,
+    label: "Todo",
+  },
+  {
+    to: `/${Routes.Routine}`,
+    icon: <BsListCheck />,
+    label: "Routine",
+  },
+  {
+    to: `/${Routes.Habit}`,
+    icon: <BsCheck2Circle />,
+    label: "Habit",
+  },
+];
+
+function NavigationItem({
+  to,
+  icon,
+  label,
+}: {
+  to: string;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <button aria-label={label} className="[&:has(.active)]:active">
+      <NavLink
+        to={to}
+        className={"flex flex-col items-center justify-center text-gray-500"}
+      >
+        <span className="block max-w-max mx-auto text-lg">{icon}</span>
+        <span className="btm-nav-label text-sm">{label}</span>
+      </NavLink>
+    </button>
+  );
+}
+
 export default function BottomNavigation() {
   return (
-    <div className="btm-nav static bordered btm-nav-md">
-      <button className="[&:has(.active)]:active">
-        <NavLink to={`/${Routes.Main}`}>
-          <span className="block max-w-max mx-auto text-2xl">
-            <BsHouseDoor />
-          </span>
-          <span className="btm-nav-label">Home</span>
-        </NavLink>
-      </button>
-
-      <button className="[&:has(.active)]:active">
-        <NavLink to={`/${Routes.Todo}`}>
-          <span className="block max-w-max mx-auto text-2xl">
-            <BsCheck2Square />
-          </span>
-          <span className="btm-nav-label">Todo</span>
-        </NavLink>
-      </button>
-
-      <button className="[&:has(.active)]:active">
-        <NavLink to={`/${Routes.Routine}`}>
-          <span className="block max-w-max mx-auto text-2xl">
-            <BsListCheck />
-          </span>
-          <span className="btm-nav-label">Routine</span>
-        </NavLink>
-      </button>
-
-      <button className="[&:has(.active)]:active">
-        <NavLink to={`/${Routes.Habit}`}>
-          <span className="block max-w-max mx-auto text-2xl">
-            <BsCheck2Circle />
-          </span>
-          <span className="btm-nav-label">Habit</span>
-        </NavLink>
-      </button>
+    <div className="btm-nav btm-nav-sm root-content">
+      {NavigationList.map(({ to, icon, label }) => (
+        <NavigationItem key={to} to={to} icon={icon} label={label} />
+      ))}
     </div>
   );
 }

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -64,7 +64,7 @@ export default function Messages() {
 
   return (
     <div
-      className={`absolute left-0 right-0 bottom-0 flex flex-col gap-3 z-50`}
+      className={`fixed left-0 right-0 bottom-0 flex flex-col gap-3 z-50 root-content`}
     >
       {messageList}
     </div>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from "react";
+import { createPortal } from "react-dom";
 
 interface Props {
   title: string;
@@ -11,11 +12,11 @@ interface Props {
 
 const Modal = forwardRef<HTMLDialogElement, Props>(
   ({ id, title, children, buttons }, ref) => {
-    return (
+    return createPortal(
       <dialog
         ref={ref}
         id={id}
-        className="modal rounded-lg shadow-lg p-3 pb-0 modal-bottom z-1"
+        className="modal rounded-lg shadow-lg p-3 modal-bottom pb-0 z-1"
       >
         <div className="modal-box flex flex-col max-w-lg mx-auto">
           <div className="flex-1">
@@ -30,7 +31,8 @@ const Modal = forwardRef<HTMLDialogElement, Props>(
             {buttons}
           </div>
         </div>
-      </dialog>
+      </dialog>,
+      document.getElementById("root") || document.body
     );
   }
 );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
+import { BsJustify } from "react-icons/bs";
 
 import Routes from "@/constants/routes";
 import { useAuthStore } from "@/state/useAuthStore";
@@ -41,7 +42,7 @@ const NavBar = () => {
       return (
         <ul
           tabIndex={0}
-          className="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52"
+          className="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-badge w-52"
         >
           <li>
             <Link to={`/${Routes.Login}`}>로그인</Link>
@@ -56,7 +57,7 @@ const NavBar = () => {
     return (
       <ul
         tabIndex={0}
-        className="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52"
+        className="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-badge w-52"
       >
         <li onClick={handleLogout}>
           <Link to={""}>로그아웃</Link>
@@ -66,35 +67,23 @@ const NavBar = () => {
   };
 
   return (
-    <div className="navbar bg-base-100 z-20 bordered">
+    <div className="navbar z-20 bg-white shadow-sm fixed bordered root-content">
       <div className="navbar-start">
-        <div className="dropdown">
-          <div tabIndex={0} role="button" className="btn btn-ghost btn-circle">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-5 w-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M4 6h16M4 12h16M4 18h7"
-              />
-            </svg>
-          </div>
-          {renderNavItems(getIsLoggedIn())}
-        </div>
-      </div>
-
-      <div className="navbar-center">
-        <Link to={`/${Routes.Main}`} className="btn btn-ghost text-3xl">
+        <Link to={`/${Routes.Main}`} className="btn btn-ghost text-xl">
           Taskie
         </Link>
       </div>
-      <div className="navbar-end"></div>
+
+      <div className="navbar-center"></div>
+      <div className="navbar-end">
+        <div className="dropdown dropdown-left">
+          <div tabIndex={0} role="button" className="btn btn-ghost btn-circle">
+            <BsJustify className="text-xl" />
+          </div>
+
+          {renderNavItems(getIsLoggedIn())}
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/todo/CompletedTodoList.tsx
+++ b/src/components/todo/CompletedTodoList.tsx
@@ -16,7 +16,7 @@ export default function CompletedTodoList({
   onTodoClick,
 }: Props) {
   if (todoList.length === 0) {
-    return <p className="text-center my-4">완료한 투두 목록이 없어요.</p>;
+    return <p className="text-center my-4">완료한 할일 목록이 없어요.</p>;
   }
 
   return (

--- a/src/components/todo/TodoList.tsx
+++ b/src/components/todo/TodoList.tsx
@@ -72,15 +72,6 @@ export default function TodoList({
           );
         })}
       </ul>
-
-      {todoList.length > 0 && (
-        <button
-          onClick={onAddTodoClick}
-          className="btn btn-primary btn-outline btn-sm mt-4"
-        >
-          할 일 추가하기
-        </button>
-      )}
     </>
   );
 }

--- a/src/hooks/useTodoMutations.tsx
+++ b/src/hooks/useTodoMutations.tsx
@@ -40,7 +40,7 @@ export default function useTodoMutations(reloadTodoList: () => void) {
       updateModalState.closeModal();
       reloadTodoList();
     },
-    onError: () => addFailureMessage("투두 추가에 실패했습니다."),
+    onError: () => addFailureMessage("할일 추가에 실패했습니다."),
   });
 
   const onTodoUpdateSuccess = () => {
@@ -52,7 +52,7 @@ export default function useTodoMutations(reloadTodoList: () => void) {
     mutationFn: (input: TodoUpdateInputParameter) =>
       todoApi.updateTodo(input.id, input.update),
     onSuccess: onTodoUpdateSuccess,
-    onError: () => addFailureMessage("투두 수정에 실패했습니다."),
+    onError: () => addFailureMessage("할일 수정에 실패했습니다."),
   });
 
   const onUpdateTodoSubmit = (todo: TodoModalSubmitProps) => {
@@ -71,7 +71,7 @@ export default function useTodoMutations(reloadTodoList: () => void) {
   const deleteTodoMutation = useMutation({
     mutationFn: todoApi.deleteTodo,
     onSuccess: onTodoUpdateSuccess,
-    onError: () => addFailureMessage("투두 삭제에 실패했습니다."),
+    onError: () => addFailureMessage("할일 삭제에 실패했습니다."),
   });
 
   const onUpdateTodoChecked = (todo: TodoPublic, checked: boolean) => {

--- a/src/index.css
+++ b/src/index.css
@@ -13,3 +13,7 @@
   ) {
   scrollbar-gutter: inherit;
 }
+
+.root-content {
+  @apply max-w-lg mx-auto;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -17,3 +17,7 @@
 .root-content {
   @apply max-w-lg mx-auto;
 }
+
+.float-btn {
+  @apply btn px-6 btn-primary fixed right-4 bottom-16 rounded-badge shadow-lg z-10;
+}

--- a/src/pages/HabitPage/HabitList.tsx
+++ b/src/pages/HabitPage/HabitList.tsx
@@ -1,3 +1,5 @@
+import { BsPlusLg } from "react-icons/bs";
+
 import { HabitWithLog } from "@/api/generated";
 import { getWeek, parseRepeatDays } from "@/utils/time";
 import HabitModal from "@/components/habit/HabitModal";
@@ -89,14 +91,10 @@ export default function HabitList({
         <ul className="flex flex-col">{renderHabitList(habitList)}</ul>
       )}
 
-      {habitList.length > 0 && (
-        <button
-          onClick={openCreateModal}
-          className="btn btn-primary btn-outline btn-sm mt-2"
-        >
-          습관 추가하기
-        </button>
-      )}
+      <button onClick={openCreateModal} className="float-btn">
+        <BsPlusLg />
+        습관 추가하기
+      </button>
 
       <HabitModal
         modalRef={createModalRef}

--- a/src/pages/HabitPage/HabitList.tsx
+++ b/src/pages/HabitPage/HabitList.tsx
@@ -9,12 +9,28 @@ import DisabledHabit from "./DisabledHabit";
 
 interface Props {
   date: Date;
+  isLoading: boolean;
   habitList: HabitWithLog[];
 
   reloadHabitList: () => void;
 }
 
-export default function HabitList({ date, habitList, reloadHabitList }: Props) {
+function HabitSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="skeleton h-24 w-48"></div>
+      <div className="skeleton h-24"></div>
+      <div className="skeleton h-24"></div>
+    </div>
+  );
+}
+
+export default function HabitList({
+  isLoading,
+  date,
+  habitList,
+  reloadHabitList,
+}: Props) {
   const {
     createHabitModal,
     updateHabitModal,
@@ -67,7 +83,12 @@ export default function HabitList({ date, habitList, reloadHabitList }: Props) {
 
   return (
     <>
-      <ul className="flex flex-col">{renderHabitList(habitList)}</ul>
+      {isLoading ? (
+        <HabitSkeleton />
+      ) : (
+        <ul className="flex flex-col">{renderHabitList(habitList)}</ul>
+      )}
+
       {habitList.length > 0 && (
         <button
           onClick={openCreateModal}

--- a/src/pages/HabitPage/index.tsx
+++ b/src/pages/HabitPage/index.tsx
@@ -30,15 +30,12 @@ export default function HabitPage() {
     refetchInterval: 60 * 1000,
   });
 
-  if (isLoading) {
-    return <Loading />;
-  }
-
   return (
     <div>
       <h1 className="text-2xl font-semibold mb-3">습관</h1>
       <HabitList
         reloadHabitList={invalidateQueries}
+        isLoading={isLoading}
         habitList={data?.data || []}
         date={date}
       />

--- a/src/pages/HabitPage/index.tsx
+++ b/src/pages/HabitPage/index.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 
 import { habitsApi, queryClient } from "@/api/client";
 import { formatDate } from "@/utils/time";
-import Loading from "@/components/Loading";
 
 import HabitList from "./HabitList";
 

--- a/src/pages/MainPage/Habit/HabitSection.tsx
+++ b/src/pages/MainPage/Habit/HabitSection.tsx
@@ -134,15 +134,14 @@ export default function HabitSection({ habitList, reloadHabitList }: Props) {
   return (
     <>
       <ul>{renderHabitList(habitList)}</ul>
-      {habitList.length ? (
+
+      {habitList.length > 0 && (
         <button
           onClick={openCreateModal}
-          className="btn btn-primary btn-outline btn-sm mt-2"
+          className="btn btn-primary btn-outline btn-block mt-2"
         >
           습관 추가하기
         </button>
-      ) : (
-        <></>
       )}
 
       <HabitModal

--- a/src/pages/MainPage/Routine/RoutineSection.tsx
+++ b/src/pages/MainPage/Routine/RoutineSection.tsx
@@ -41,7 +41,7 @@ export default function RoutineSection({ routineList }: Props) {
 
       {routineList.length > 0 && (
         <Link to={`/${Routes.RoutineCreate}`}>
-          <button className="btn btn-primary btn-outline btn-sm mt-2">
+          <button className="btn btn-primary btn-outline btn-block mt-2">
             루틴 추가하러 가기
           </button>
         </Link>

--- a/src/pages/MainPage/Todo/TodoSection.tsx
+++ b/src/pages/MainPage/Todo/TodoSection.tsx
@@ -60,6 +60,15 @@ export default function TodoSection({ date, todoList, reloadTodoList }: Props) {
         onTodoCheck={onUpdateTodoChecked}
       />
 
+      {todoList.length > 0 && (
+        <button
+          onClick={createModalState.openModal}
+          className="btn btn-primary btn-outline btn-block mt-4"
+        >
+          할 일 추가하기
+        </button>
+      )}
+
       <TodoModal
         ref={createModalState.modalRef}
         key={createModalState.isModalOpened ? "open" : "close"}

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -3,7 +3,6 @@ import Datepicker, { DateValueType } from "react-tailwindcss-datepicker";
 import { useState } from "react";
 
 import { queryClient, taskApi } from "@/api/client";
-import Loading from "@/components/Loading";
 import { formatDate } from "@/utils/time";
 
 import TodoSection from "./Todo/TodoSection";
@@ -33,10 +32,6 @@ function MainPage() {
     if (date) setTargetDate(date);
   };
 
-  if (isLoading) {
-    return <Loading />;
-  }
-
   return (
     <>
       <Datepicker
@@ -57,24 +52,46 @@ function MainPage() {
       <div className="container my-5">
         <h2 className="text-xl mb-2">할 일</h2>
 
-        <TodoSection
-          date={targetDate}
-          todoList={data?.data?.todo_list || []}
-          reloadTodoList={refetch}
-        />
+        {isLoading ? (
+          <div className="flex flex-col gap-4">
+            <div className="skeleton h-10 w-28"></div>
+            <div className="skeleton h-10"></div>
+            <div className="skeleton h-10"></div>
+          </div>
+        ) : (
+          <TodoSection
+            date={targetDate}
+            todoList={data?.data?.todo_list || []}
+            reloadTodoList={refetch}
+          />
+        )}
       </div>
 
       <div className="container mb-5">
         <h2 className="text-xl mb-2">습관</h2>
-        <HabitSection
-          habitList={data?.data?.habit_list || []}
-          reloadHabitList={refetch}
-        />
+        {isLoading ? (
+          <div className="flex flex-col gap-4">
+            <div className="skeleton h-12"></div>
+            <div className="skeleton h-12"></div>
+          </div>
+        ) : (
+          <HabitSection
+            habitList={data?.data?.habit_list || []}
+            reloadHabitList={refetch}
+          />
+        )}
       </div>
 
       <div className="container mb-5">
         <h2 className="text-xl mb-2">루틴</h2>
-        <RoutineSection routineList={data?.data?.routine_list || []} />
+        {isLoading ? (
+          <div className="flex flex-col gap-4">
+            <div className="skeleton h-20"></div>
+            <div className="skeleton h-20"></div>
+          </div>
+        ) : (
+          <RoutineSection routineList={data?.data?.routine_list || []} />
+        )}
       </div>
     </>
   );

--- a/src/pages/RoutinePage/RoutineList.tsx
+++ b/src/pages/RoutinePage/RoutineList.tsx
@@ -9,10 +9,21 @@ import IncompleteRoutine from "@/components/routine/IncompleteRoutine";
 import CompletedRoutine from "@/components/routine/CompletedRoutine";
 
 interface Props {
+  isLoading: boolean;
   routineList: Array<RoutinePublic>;
 }
 
-export default function RoutineList({ routineList }: Props) {
+function RoutineLoadingSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="skeleton h-20 w-48"></div>
+      <div className="skeleton h-20"></div>
+      <div className="skeleton h-20"></div>
+    </div>
+  );
+}
+
+export default function RoutineList({ isLoading, routineList }: Props) {
   const renderRoutineList = (list: Array<RoutinePublic>) => {
     if (list.length === 0) {
       return <EmptyCard label="루틴" />;
@@ -59,7 +70,11 @@ export default function RoutineList({ routineList }: Props) {
 
   return (
     <>
-      <ul className="flex flex-col">{renderRoutineList(routineList)}</ul>
+      {isLoading ? (
+        <RoutineLoadingSkeleton />
+      ) : (
+        <ul className="flex flex-col">{renderRoutineList(routineList)}</ul>
+      )}
 
       <Link to={`/${Routes.RoutineCreate}`}>
         <button className="btn btn-circle btn-md btn-primary absolute right-0 top-0 shadow-lg">

--- a/src/pages/RoutinePage/RoutineList.tsx
+++ b/src/pages/RoutinePage/RoutineList.tsx
@@ -77,8 +77,9 @@ export default function RoutineList({ isLoading, routineList }: Props) {
       )}
 
       <Link to={`/${Routes.RoutineCreate}`}>
-        <button className="btn btn-circle btn-md btn-primary absolute right-0 top-0 shadow-lg">
+        <button className="float-btn">
           <BsPlusLg />
+          루틴 추가하기
         </button>
       </Link>
     </>

--- a/src/pages/RoutinePage/index.tsx
+++ b/src/pages/RoutinePage/index.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { routineApi } from "@/api/client";
-import Loading from "@/components/Loading";
 
 import RoutineList from "./RoutineList";
 
@@ -13,15 +12,11 @@ export default function RoutinePage() {
     refetchInterval: 60 * 1000,
   });
 
-  if (isLoading) {
-    return <Loading />;
-  }
-
   return (
     <div className="relative">
       <h1 className="text-2xl font-semibold mb-3">루틴 목록</h1>
 
-      <RoutineList routineList={data?.data || []} />
+      <RoutineList isLoading={isLoading} routineList={data?.data || []} />
     </div>
   );
 }

--- a/src/pages/TodoPage/index.tsx
+++ b/src/pages/TodoPage/index.tsx
@@ -86,7 +86,7 @@ export default function TodoPage() {
   };
 
   return (
-    <div className="relative">
+    <div className="relative pb-4">
       <h1 className="text-2xl font-semibold mb-3">할 일 목록</h1>
 
       {isLoading ? (
@@ -101,17 +101,15 @@ export default function TodoPage() {
         />
       )}
 
-      <button
-        onClick={createModalState.openModal}
-        className="btn btn-circle btn-md btn-primary absolute right-0 top-0 shadow-lg"
-      >
+      <button onClick={createModalState.openModal} className="float-btn">
         <BsPlusLg />
+        할일 추가하기
       </button>
 
       <div className="collapse collapse-arrow card-bordered shadow-sm mt-6 bg-slate-50">
         <input type="radio" name="done-todos" defaultChecked={false} />
         <div className="collapse-title text-lg font-medium">
-          완료한 투두 목록
+          완료한 할일 목록
         </div>
 
         <div className="p-2 bg-white">

--- a/src/pages/TodoPage/index.tsx
+++ b/src/pages/TodoPage/index.tsx
@@ -2,7 +2,6 @@ import { useQuery } from "@tanstack/react-query";
 import { BsPlusLg } from "react-icons/bs";
 import { useState } from "react";
 
-import Loading from "@/components/Loading";
 import TodoList from "@/components/todo/TodoList";
 import CompletedTodoList from "@/components/todo/CompletedTodoList";
 import useTodoMutations from "@/hooks/useTodoMutations";
@@ -12,6 +11,16 @@ import { TodoPublic } from "@/api/generated";
 import { API_REFETCH_INTERVAL } from "@/constants/api";
 
 import TodoModal from "../MainPage/Todo/TodoModal";
+
+function TodoLoadingSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="skeleton h-10 w-28"></div>
+      <div className="skeleton h-10"></div>
+      <div className="skeleton h-10"></div>
+    </div>
+  );
+}
 
 export default function TodoPage() {
   const [date] = useState(() => new Date());
@@ -49,10 +58,6 @@ export default function TodoPage() {
     createTodoMutation,
   } = useTodoMutations(reloadTodoList);
 
-  if (isLoading) {
-    return <Loading />;
-  }
-
   const renderTodoUpdateModal = (todo: TodoPublic | null) => {
     if (!todo) return;
 
@@ -84,13 +89,17 @@ export default function TodoPage() {
     <div className="relative">
       <h1 className="text-2xl font-semibold mb-3">할 일 목록</h1>
 
-      <TodoList
-        isGrouped
-        todoList={todoList?.data || []}
-        onAddTodoClick={createModalState.openModal}
-        onTodoClick={updateModalState.openModal}
-        onTodoCheck={onUpdateTodoChecked}
-      />
+      {isLoading ? (
+        <TodoLoadingSkeleton />
+      ) : (
+        <TodoList
+          isGrouped
+          todoList={todoList?.data || []}
+          onAddTodoClick={createModalState.openModal}
+          onTodoClick={updateModalState.openModal}
+          onTodoCheck={onUpdateTodoChecked}
+        />
+      )}
 
       <button
         onClick={createModalState.openModal}
@@ -107,7 +116,7 @@ export default function TodoPage() {
 
         <div className="p-2 bg-white">
           {doneTodoListIsLoading ? (
-            <Loading />
+            <TodoLoadingSkeleton />
           ) : (
             <CompletedTodoList
               todoList={doneTodoList?.data || []}


### PR DESCRIPTION
- 스크롤 영역이 기존엔 상단/하단 네비게이션을 제외한 메인 컨텐츠 부분만 해당이었습니다
- 이게 PC에선 괜찮은데 모바일 브라우저로 보니(ios) 스크롤을 실제로 내리고 있어도 주소창이 없어지지 않고, pull해서 새로고침 하는게 되지 않아서 전체 영역을 스크롤 하는 방식으로 변경했습니다.
- 그리고 버튼 디자인을 통일했습니다.
- 각 메인 탭들의 리스트 로딩 화면을 스켈레톤으로 변경했습니다.
- 헤더/네비게이션 디자인을 작게 변경했습니다. 그리고 헤더는 우측으로 버튼을 옮겼습니다. 

<img width="375" alt="image" src="https://github.com/user-attachments/assets/eaaec02c-9b9b-4633-ab6b-208a8635bcb7" />
