### PR TITLE
모바일에서 기본 스크롤이 생기는 현상 수정 및 Dialog를 사용하도록 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,25 @@
 import { Outlet } from "react-router-dom";
+import { useEffect } from "react";
 
 import TokenRefresher from "@/components/TokenRefresher";
 import PageHeader from "@/components/PageHeader";
 import { Toaster } from "@/components/ui/sonner";
 
+function updateViewportHeight() {
+  const vh = window.innerHeight * 0.01;
+  document.documentElement.style.setProperty("--vh", `${vh}px`);
+}
+
 export default function App() {
+  useEffect(() => {
+    updateViewportHeight();
+    window.addEventListener("resize", updateViewportHeight);
+
+    return () => window.removeEventListener("resize", updateViewportHeight);
+  }, []);
+
   return (
-    <div className="min-h-screen flex flex-col overflow-visible relative">
+    <div className="min-h-device flex flex-col overflow-visible relative">
       <PageHeader />
 
       <div className="px-6 pt-20 pb-4 flex-1 container mx-auto w-full">

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -1,24 +1,14 @@
 import { PropsWithChildren, useEffect } from "react";
 
 import {
-  Drawer,
-  DrawerContent,
-  DrawerDescription,
-  DrawerHeader,
-  DrawerTitle,
-} from "@/components/ui/drawer";
-import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
 import usePrevious from "@/hooks/usePrevious";
 import { useMounted } from "@/hooks/useMounted";
-
-import { ScrollArea } from "./scroll-area";
 
 export interface ModalOpenProps {
   isOpened: boolean;
@@ -38,7 +28,6 @@ export default function Modal({
   title,
   description,
   setIsOpened,
-  onModalInvisible,
   onModalOpen,
   children,
 }: Props & PropsWithChildren) {
@@ -51,47 +40,18 @@ export default function Modal({
     }
   }, [isOpened, previousIsOpened, onModalOpen]);
 
-  const isDesktop = useMediaQuery("(min-width: 640px)");
-
   if (!isMounted) return null;
 
-  if (isDesktop) {
-    return (
-      <Dialog open={isOpened} onOpenChange={setIsOpened}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{title}</DialogTitle>
-            {description && (
-              <DialogDescription>{description}</DialogDescription>
-            )}
-          </DialogHeader>
-
-          <div className="grid gap-4 py-4">{children}</div>
-        </DialogContent>
-      </Dialog>
-    );
-  }
-
-  const handleAnimationEnd = (isOpen: boolean) => {
-    if (!isOpen) {
-      onModalInvisible?.();
-    }
-  };
-
   return (
-    <Drawer
-      open={isOpened}
-      onOpenChange={setIsOpened}
-      onAnimationEnd={handleAnimationEnd}
-    >
-      <DrawerContent className="p-6 pt-0 max-h-[95vh]">
-        <DrawerHeader>
-          <DrawerTitle>{title}</DrawerTitle>
-          {description && <DrawerDescription>{description}</DrawerDescription>}
-        </DrawerHeader>
+    <Dialog open={isOpened} onOpenChange={setIsOpened}>
+      <DialogContent className="overflow-y-auto max-h-device">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
 
-        <ScrollArea className="p-4 pb-0 overflow-auto">{children}</ScrollArea>
-      </DrawerContent>
-    </Drawer>
+        <div className="grid gap-4">{children}</div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,7 +10,10 @@ export default {
   theme: {
     extend: {
       height: {
-        screen: ["100vh", "100dvh"],
+        device: "calc(var(--vh, 1vh) * 100)",
+      },
+      minHeight: {
+        device: "calc(var(--vh, 1vh) * 100)",
       },
       borderRadius: {
         lg: "var(--radius)",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,9 @@ export default {
       minHeight: {
         device: "calc(var(--vh, 1vh) * 100)",
       },
+      maxHeight: {
+        device: "calc(var(--vh, 1vh) * 100)",
+      },
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",


### PR DESCRIPTION
- min-height가 100vh로 설정되어 있어서, 모바일 브라우저의 경우 주소창 때문에 기본 스크롤이 생기는 문제를 해결했습니다.
- drawer를 사용해서 실제 모바일 ui에서 확인하니까 키보드가 올라왔을 때 크기가 너무 작아서 보기 불편해지는 걸 확인했습니다. 그래서 pc-mobile 모두 dialog로 처리하도록 변경했습니다